### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,15 @@ Third party project for GacUI 1.0: https://github.com/mangosroom/GacUI-CMake-sup
 This project is not maintained by members in **vczh-libraries** organization.
 In the future there could be some mismatch in the file list,
 which could be easily fixed.
+
+## Building using vcpkg
+
+You can build and install vlpp using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+  - git clone https://github.com/Microsoft/vcpkg.git
+  - cd vcpkg
+  - ./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
+  - ./vcpkg integrate install
+  - ./vcpkg install vlpp
+
+The vlpp port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.


### PR DESCRIPTION
vlpp is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for vlpp and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build vlpp, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/vlpp/portfile.cmake). We try to keep the library maintained as close as possible to the original library.